### PR TITLE
disable Style/SingleLineBlockParams cop

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -308,7 +308,7 @@ Style/SignalException:
   Enabled: false
 
 Style/SingleLineBlockParams:
-  Enabled: true
+  Enabled: false
 
 Style/SingleLineMethods:
   Enabled: true


### PR DESCRIPTION
It wants you to call the block params |a, e| in this case:
rental_not_included_taxes.inject(0) { |total, tax| total += tax.rounded_amount }
