### PR TITLE
SingleLineBlockParams rule disabled

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -212,7 +212,7 @@ Lint/EndAlignment:
   Enabled: true
 
 Style/SingleLineBlockParams:
-  Enabled: true
+  Enabled: false
 
 Style/SymbolArray:
   Enabled: false


### PR DESCRIPTION
It wants me to generalize variable names which makes the code less expressive, so I disabled it.
http://www.rubydoc.info/github/bbatsov/rubocop/Rubocop/Cop/Style/SingleLineBlockParams