### PR TITLE
disable Layout/AlignHash

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -25,8 +25,7 @@ Layout/AlignArray:
   Enabled: true
 
 Layout/AlignHash:
-  EnforcedLastArgumentHashStyle: always_ignore
-  Enabled: true
+  Enabled: false
 
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation


### PR DESCRIPTION
This really depends on the context and I would leave this to the writer to decide.
In this example, it bothers me:
```
def do_create
  post :create, params: { rental_id: rental.id, remote_account_id: remote_account.id,
                          remote_rental_unit_id: remote_rental_unit.id }
end
```

I would write it like this:
```
def do_create
  post :create, params: { rental_id: rental.id, remote_account_id: remote_account.id,
    remote_rental_unit_id: remote_rental_unit.id }
end
```