### PR TITLE
Layout/AlignArray disable

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -22,7 +22,7 @@ Style/Alias:
   EnforcedStyle: prefer_alias_method
 
 Layout/AlignArray:
-  Enabled: true
+  Enabled: false
 
 Layout/AlignHash:
   Enabled: false


### PR DESCRIPTION
It wants me to write this:
```
factory :some_factory, traits: [:with_photos, :with_bells_and_whistles, :with_a_red_ribbon,
  :with_fluffy_rabbits, :with_ice, :running_out_of_examples_but_i_think_you_get_the_point,
  :and_here_comes_another_line]
```

Like this:
```
factory :some_factory, traits: [:with_photos, :with_bells_and_whistles, :with_a_red_ribbon,
                                :with_fluffy_rabbits, :with_ice,
                                :running_out_of_examples_but_i_think_you_get_the_point,
                                :and_here_comes_another_line]
```