### PR TITLE
Update Rubocop to 1.40

### DIFF
--- a/bookingsync-stylecheck.gemspec
+++ b/bookingsync-stylecheck.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.homepage      = "https://gihub.com/BookingSync/bookingsync-stylecheck"
   s.license       = "MIT"
 
-  s.add_dependency "rubocop", "~> 0.92.0"
+  s.add_dependency "rubocop", "~> 1.4"
   s.add_development_dependency "rake"
 end

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,6 +1,7 @@
 # These are all the cops that are enabled in the default configuration.
 AllCops:
   DisabledByDefault: true
+  SuggestExtensions: false
   # If .ruby-version exists and it contains an MRI version it is used.
   # Otherwise we fallback to the oldest officially supported Ruby version.
   TargetRubyVersion: ~
@@ -122,6 +123,7 @@ Style/Encoding:
 
 Style/HashSyntax:
   Enabled: true
+  EnforcedShorthandSyntax: never
 
 Layout/IndentationConsistency:
   Enabled: true


### PR DESCRIPTION
The old rubocop version did not support ruby 3.1

Error message when running `bundle exec rubocop`:
```
RuboCop found unknown Ruby version 3.1 in `.ruby-version`.
Supported versions: 2.4, 2.5, 2.6, 2.7, 3.0
```

